### PR TITLE
Fixing issue 25 where make pip installs cached requirements if availa…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ lint:
 	pylint hop
 
 pip:
-	pip install -r requirements.txt
-	pip install -r test-requirements.txt
+	pip install -r requirements.txt --no-cache-dir
+	pip install -r test-requirements.txt --no-cache-dir
 
 dockerimages:
 	docker pull gocd/gocd-server:latest


### PR DESCRIPTION
…ble forcing it to install docker 2.3.0 instead of 2.1.0 which breaks build