### PR TITLE
Refactored dip init to use cookiecutter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ pip:
 	pip install -r test-requirements.txt --no-cache-dir
 
 dockerimages:
-	docker pull gocd/gocd-server:latest
+	docker pull gocd/gocd-server-deprecated:latest
 	docker pull gocd/gocd-agent-deprecated
 
 requirements: pip dockerimages

--- a/hop/cli/__init__.py
+++ b/hop/cli/__init__.py
@@ -13,6 +13,7 @@ def create_parser():
 
     init_parser = sparser.add_parser('init', help='initializes hop')
     init_parser.add_argument('dest_dir', help='destination directory for hop')
+    # init_parser.add_argument('--type', default='hop', help='the type of initialization, default is initialize hop')
     init_parser.add_argument('--skip-passwd', help='skip creating passwd file during init', dest='create_passwd',
                              action='store_false')
     init_parser.set_defaults(create_passwd=True)

--- a/hop/cli/commands/init.py
+++ b/hop/cli/commands/init.py
@@ -4,6 +4,7 @@ import os
 import sys
 import logging
 
+from cookiecutter.main import cookiecutter
 from hop.core import write_yaml, read_yaml
 from hop.core.hop_config import HopConfig
 
@@ -24,11 +25,11 @@ provider:
         instances: 2
 '''
 
+
 def execute(args, **kwargs):  # pylint: disable=unused-argument
     hop_dir = Path(args.dest_dir)
-    hop_dir.mkdir(parents=True)
     hop_config = hop_dir / 'hop.yml'
-    config = generate_hop_config(hop_config, installation_name=hop_dir.name)
+    config = generate_hop_config(hop_config, installation_name=hop_dir.name, dest_dir=hop_dir)
     hop_config = HopConfig(config)
     if args.create_passwd:
         get_admin_password(hop_dir, hop_config)
@@ -36,6 +37,7 @@ def execute(args, **kwargs):  # pylint: disable=unused-argument
 
 def _sh_htpasswd():
     return sh.htpasswd  # pylint: disable=no-member
+
 
 def htpasswd_fn():
     try:
@@ -57,7 +59,7 @@ def get_admin_password(hop_dir, hop_config):
     write_yaml({'password': password}, os.path.expanduser('~/.hop{}'.format(hop_config.name)))
 
 
-def generate_hop_config(hop_file, installation_name):
-    hop_file.touch()
-    hop_file.write_text(BASE_HOP_CONFIG.format(installation_name))
+def generate_hop_config(hop_file, installation_name, dest_dir):
+    cookiecutter('https://github.com/crohacz/cookiecutter-hop-template.git', no_input=True,
+                 extra_context={'installation_name': installation_name, 'dest_dir': dest_dir})
     return read_yaml(hop_file.as_posix())

--- a/hop/providers/local_docker/provisioner.py
+++ b/hop/providers/local_docker/provisioner.py
@@ -53,11 +53,11 @@ class LocalDockerConfig(HopConfig):
 
     @property
     def server_image(self):
-        return self.get('provider.server.image', 'gocd/gocd-server')
+        return self.get('provider.server.image', 'gocd/gocd-server-deprecated')
 
     @property
     def agent_image(self):
-        return self.get('provider.agents.image', 'gocd/gocd-agent')
+        return self.get('provider.agents.image', 'gocd/gocd-agent-deprecated')
 
     @property
     def https_url(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ docker==2.1.0
 requests
 gomatic
 sh
+cookiecutter

--- a/test/testintegration/cli/test_init_command.py
+++ b/test/testintegration/cli/test_init_command.py
@@ -27,7 +27,6 @@ provider:
 '''
 
 
-
 class TestInitCommand(unittest.TestCase):
     def setUp(self):
         self.parser = create_parser()


### PR DESCRIPTION
Since dip init will be using cookiecutter to create plans and providers in the future, it made sense to have dip init for hop use cookiecutter as well. 